### PR TITLE
feat: implement to clean artifacts before sync directory #14

### DIFF
--- a/src/cmd_push.c
+++ b/src/cmd_push.c
@@ -9,6 +9,15 @@
 
 static int backup_to_gdrive(const char *msg);
 void execute_push(const char *msg){
+    // 0. make clean
+    if (run_command("cd xv6-public && make clean") < 0){
+        fprintf(stderr, "Error: Failed to clean the build artifacts.\n");
+        exit(EXIT_FAILURE);
+    }
+    if (run_command("cd ..") < 0){
+        fprintf(stderr, "Error: Failed to change directory.\n");
+        exit(EXIT_FAILURE);
+    }
     char sync_command[1024];
     // 1. copy to output_dir
     snprintf(sync_command, sizeof(sync_command), 


### PR DESCRIPTION
## Related Issue
- #14 

## Description
- `googit push`에서 build artifacts가 백업 대상에 포함되는 현상 해결

## Details
- `rsync` 실행 전 `make clean` 실행

##  References
-